### PR TITLE
fix: docker build slate installation

### DIFF
--- a/.github/workflows/slate-builder-actions.yml
+++ b/.github/workflows/slate-builder-actions.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build documentation
-      uses: ./
+      uses: /
       env:
         DOC_BASE_FOLDER: .
         ZIP_BUILD: false

--- a/.github/workflows/slate-builder-actions.yml
+++ b/.github/workflows/slate-builder-actions.yml
@@ -8,7 +8,7 @@ jobs:
     - name: Build documentation
       uses: ./
       env:
-        DOC_BASE_FOLDER: .
+        DOC_BASE_FOLDER: ./test-documentation/
         ZIP_BUILD: false
     - name: Deploy to GitHub Pages
       uses: maxheld83/ghpages@v0.2.1

--- a/.github/workflows/slate-builder-actions.yml
+++ b/.github/workflows/slate-builder-actions.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build documentation
-      uses: /
+      uses: ./
       env:
         DOC_BASE_FOLDER: .
         ZIP_BUILD: false

--- a/.github/workflows/slate-builder-actions.yml
+++ b/.github/workflows/slate-builder-actions.yml
@@ -4,7 +4,7 @@ jobs:
   action-filter:
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
     - name: Build documentation
       uses: ./
       env:

--- a/.github/workflows/slate-builder-actions.yml
+++ b/.github/workflows/slate-builder-actions.yml
@@ -11,7 +11,8 @@ jobs:
         DOC_BASE_FOLDER: ./test-documentation/
         ZIP_BUILD: false
     - name: Deploy to GitHub Pages
-      uses: maxheld83/ghpages@v0.2.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        BUILD_DIR: test-documentation/build/
+      uses: JamesIves/github-pages-deploy-action@releases/v3
+      with:
+        ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+        BRANCH: gh-pages
+        FOLDER: test-documentation/build 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3-alpine
+FROM ruby:2.7-alpine
 LABEL maintainer="developers@decathlon.com"
 LABEL "com.github.actions.name"="Slate Documentation builder"
 LABEL "com.github.actions.description"="Build repository md files using the slate framework"

--- a/action.yml
+++ b/action.yml
@@ -1,10 +1,9 @@
 name: Slate documentation builder
 author: Decathlon <developers@decathlon.com>
-description: This Github action <strong>builds repositories Markdown files</strong> using slate framework.
-The slate build result will be stored into the build subdirectory of <md files folder>.
+description: This Github action <strong>builds repositories Markdown files</strong> using slate framework. The slate build result will be stored into the build subdirectory of <md files folder>.
 runs:
   using: 'docker'
-  image: 'docker://decathlon/slate-builder-action:2.0.0'
+  image: 'Dockerfile'
 branding:
   icon: tag
   color: blue


### PR DESCRIPTION
# CI Failure in V2.0.0

## Why?
Due to an incompatibility on the latest Slate version and Ruby < 2.3, the CI build was failing in our latest version. Maybe related to some cache in the docker image used during the build.
![image](https://user-images.githubusercontent.com/139323/73885178-a2e57700-4867-11ea-8b97-75e8d0f61402.png)

## What?
Moving the Docker base image used for this action to the latest available alpine Ruby.

As the CI was broken too, I take the time to fix the CI directly within this PR. Right now any time we are pushing the action itself (nevermind the branch we are using) is used to build the sample documentation provided within this repository.
If all is working good the result is auto-published on this repo gh-pages: https://decathlon.github.io/slate-builder-action
We can check the build status directly within the PR or the Actions menu:
![image](https://user-images.githubusercontent.com/139323/73890121-82221f00-4871-11ea-85f6-d00f91a15ae7.png)

